### PR TITLE
ci: fix gradle can't find openjdk

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 1.8
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
-        distribution: 'openjdk'
+        java-version: '8'
+        distribution: 'temurin'
     - name: Build with Gradle
       uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
       with:


### PR DESCRIPTION
Changed Java version and fixed openjdk not found from changing it to temurin distribution.